### PR TITLE
feat: Add Docker Compose and Dockerfiles for MCP servers

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,2 @@
-GITHUB_TOKEN=YOUR_GITHUB_TOKEN
+GITHUB_TOKEN=your_github_token_here
+NOTION_TOKEN=your_notion_token_here

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ mcp.json に使用したい MCP を定義する。
 
 docker を立ち上げてエンドポイントを設定するか、個別に入れる。
 
+-   [mpcs/README.md](./mpcs/README.md)
+
 # Cursor Rules(Project Rules)
 
 cursor に適用させるルールを記載する。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: "3.8"
+
+services:
+    figma-mcp:
+        build:
+            context: ./mpcs/figma
+        ports:
+            - "3000:3000"
+        restart: unless-stopped
+        networks:
+            - mcp-network
+        environment:
+            - NODE_ENV=production
+
+    git-mcp:
+        build:
+            context: ./mpcs/git
+        ports:
+            - "3005:3005"
+        restart: unless-stopped
+        networks:
+            - mcp-network
+        environment:
+            - NODE_ENV=production
+
+    github-mcp:
+        build:
+            context: ./mpcs/github
+        ports:
+            - "3002:3002"
+        restart: unless-stopped
+        networks:
+            - mcp-network
+        environment:
+            - NODE_ENV=production
+            - GITHUB_TOKEN=${GITHUB_TOKEN}
+
+    notion-mcp:
+        build:
+            context: ./mpcs/notion
+        ports:
+            - "3001:3001"
+        restart: unless-stopped
+        networks:
+            - mcp-network
+        environment:
+            - NODE_ENV=production
+            - NOTION_TOKEN=${NOTION_TOKEN}
+
+    memory-mcp:
+        build:
+            context: ./mpcs/memory
+        ports:
+            - "3003:3003"
+        restart: unless-stopped
+        networks:
+            - mcp-network
+        environment:
+            - NODE_ENV=production
+
+networks:
+    mcp-network:
+        driver: bridge

--- a/mpcs/README.md
+++ b/mpcs/README.md
@@ -1,0 +1,46 @@
+# MCP (Model Context Protocol) サーバーコンテナ
+
+このディレクトリには、各種 MCP サーバーの Dockerfile 構成が含まれています。
+
+## サポートしている MCP サーバー
+
+-   **Figma MCP**: Figma のコンテキスト情報を取得するサーバー（ポート 3000）
+-   **Git MCP**: Git リポジトリのコンテキスト情報を取得するサーバー（ポート 3005）
+-   **GitHub MCP**: GitHub のコンテキスト情報を取得するサーバー（ポート 3002）
+-   **Notion MCP**: Notion のコンテキスト情報を取得するサーバー（ポート 3001）
+-   **Memory MCP**: メモリコンテキスト情報を管理するサーバー（ポート 3003）
+
+## 使用方法
+
+プロジェクトのルートディレクトリで以下のコマンドを実行します：
+
+```bash
+# 環境変数の設定
+cp .env.sample .env
+# .envファイルを編集して、必要なトークンを設定
+
+# Docker コンテナの構築と起動
+docker-compose up -d
+
+# 特定のサービスのみ構築・起動する場合
+docker-compose up -d figma-mcp github-mcp
+
+# ログの確認
+docker-compose logs -f
+
+# コンテナの停止
+docker-compose down
+```
+
+## 環境変数
+
+-   `GITHUB_TOKEN`: GitHub API へのアクセスに必要なトークン
+-   `NOTION_TOKEN`: Notion API へのアクセスに必要なトークン
+
+## 参考リンク
+
+-   [Figma MCP](https://github.com/GLips/Figma-Context-MCP)
+-   [Git MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
+-   [GitHub MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/github)
+-   [Notion MCP](https://github.com/v-3/notion-server)
+-   [Memory MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/memory)

--- a/mpcs/figma/Dockerfile
+++ b/mpcs/figma/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# リポジトリをクローン
+RUN apk add --no-cache git && \
+    git clone https://github.com/GLips/Figma-Context-MCP.git . && \
+    apk del git
+
+# 依存関係をインストール
+RUN npm install
+
+# アプリケーションをビルド
+RUN npm run build
+
+# ポートを開放
+EXPOSE 3000
+
+# アプリケーションを実行
+CMD ["npm", "start"] 

--- a/mpcs/git/Dockerfile
+++ b/mpcs/git/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# リポジトリをクローン
+RUN apk add --no-cache git && \
+    git clone https://github.com/modelcontextprotocol/servers.git && \
+    cp -r servers/src/git/* . && \
+    rm -rf servers && \
+    apk del git
+
+# 依存関係をインストール
+RUN npm install
+
+# ポートを開放
+EXPOSE 3005
+
+# アプリケーションを実行
+CMD ["node", "index.js"] 

--- a/mpcs/github/Dockerfile
+++ b/mpcs/github/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# リポジトリをクローン
+RUN apk add --no-cache git && \
+    git clone https://github.com/modelcontextprotocol/servers.git && \
+    cp -r servers/src/github/* . && \
+    rm -rf servers && \
+    apk del git
+
+# 依存関係をインストール
+RUN npm install
+
+# ポートを開放
+EXPOSE 3002
+
+# アプリケーションを実行
+CMD ["node", "index.js"] 

--- a/mpcs/memory/Dockerfile
+++ b/mpcs/memory/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# リポジトリをクローン
+RUN apk add --no-cache git && \
+    git clone https://github.com/modelcontextprotocol/servers.git && \
+    cp -r servers/src/memory/* . && \
+    rm -rf servers && \
+    apk del git
+
+# 依存関係をインストール
+RUN npm install
+
+# ポートを開放
+EXPOSE 3003
+
+# アプリケーションを実行
+CMD ["node", "index.js"] 

--- a/mpcs/notion/Dockerfile
+++ b/mpcs/notion/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# リポジトリをクローン
+RUN apk add --no-cache git && \
+    git clone https://github.com/v-3/notion-server.git . && \
+    apk del git
+
+# 依存関係をインストール
+RUN npm install
+
+# ポートを開放
+EXPOSE 3001
+
+# アプリケーションを実行
+CMD ["node", "index.js"] 


### PR DESCRIPTION
- Create docker-compose.yml with configurations for Figma, Git, GitHub, Notion, and Memory MCPs
- Add Dockerfiles for each MCP server with specific repository cloning and setup
- Update .env.sample to include Notion token
- Create README.md in mpcs directory with usage instructions and server details