### PR TITLE
READMEの更新：サポートしているMCPサーバーの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ mcp.json に使用したい MCP を定義する。
 
 -   [.cursor/README.md](.cursor/README.md)
 
+# サポートしているMCPサーバー
+
+- **Figma MCP**: Figmaのデザイン情報を取得するためのサーバー
+- **GitHub MCP**: GitHubのリポジトリ操作を行うためのサーバー
+- **Notion MCP**: Notionのデータベースやページを操作するためのサーバー
+
 # Cursor Rules(Project Rules)
 
 cursor に適用させるルールを記載する。


### PR DESCRIPTION
## 概要
READMEにサポートしているMCPサーバーの情報を追加しました。

## 変更内容
- Figma MCPの説明を追加
- GitHub MCPの説明を追加
- Notion MCPの説明を追加

## 関連Issue
なし